### PR TITLE
Updating actions/core js lib to 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "ncc build index.js"
   },
   "dependencies": {
-    "@actions/core": "^1.2.6",
+    "@actions/core": "^1.10.0",
     "uuid": "^3.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Updating `@acitons/core` to the [1.10.0 release](https://github.com/actions/toolkit/commit/295cbcc4daea2cd1745738dabdb716938f815dc1), which removes the deprecated `setOutput` function.